### PR TITLE
Update to match latest hypebeat-go-osc API

### DIFF
--- a/osc.go
+++ b/osc.go
@@ -7,13 +7,22 @@ import (
 )
 
 func listenOSCFeedback() {
-	addr := "127.0.0.1:8000"
-	server := &osc.Server{Addr: addr}
-
-	server.Handle("*", func(msg *osc.Message) {
+	d := osc.NewStandardDispatcher()
+	err := d.AddMsgHandler("*", func(msg *osc.Message) {
 		osc.PrintMessage(msg)
 	})
+	if err != nil {
+		fmt.Printf("Error creating osc dispatcher for OSC feedback: %v\n", err)
+		return
+	}
 
 	fmt.Println("Listening on :8000 for incoming OSC feedback")
-	server.ListenAndServe()
+	err = (&osc.Server{
+		Addr:       "127.0.0.1:8000",
+		Dispatcher: d,
+	}).ListenAndServe()
+	if err != nil {
+		fmt.Printf("Error listening for OSC feedback: %v\n", err)
+		return
+	}
 }


### PR DESCRIPTION
I've updated this for you to match the latest API from https://github.com/hypebeast/go-osc

It seems that your project dependencies are vendored using an old tool. Nowadays, the Go community uses Go modules (https://github.com/golang/go/wiki/Modules) to do this, so I would recommend that you read around and move to doing so, too. It will be much better supported for your project going forward.